### PR TITLE
Suport ES 2.2.0

### DIFF
--- a/es-plugin.properties
+++ b/es-plugin.properties
@@ -1,1 +1,0 @@
-plugin=io.citrine.pluginplussign.plugin.PlusSignPlugin

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.elasticsearch</groupId>
+	<artifactId>plus_sign</artifactId>
+	<version>1.0</version>
+	<name>plus_sign</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>2.2.0</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<finalName>${project.artifactId}</finalName>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.5.5</version>
+				<configuration>
+					<appendAssemblyId>false</appendAssemblyId>
+					<outputDirectory>${project.build.directory}/releases/</outputDirectory>
+					<descriptors>
+						<descriptor>${basedir}/src/main/assemblies/plugin.xml</descriptor>
+					</descriptors>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>plugin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/java/org/elasticsearch/pluginplussign/analysis/EmptyStringTokenFilter.java
+++ b/src/main/java/org/elasticsearch/pluginplussign/analysis/EmptyStringTokenFilter.java
@@ -1,4 +1,5 @@
-package io.citrine.pluginplussign.analysis;
+package org.elasticsearch.pluginplussign.analysis;
+
 import  org.apache.lucene.analysis.TokenFilter;
 import  org.apache.lucene.analysis.TokenStream;
 import  org.apache.lucene.analysis.tokenattributes.CharTermAttribute;

--- a/src/main/java/org/elasticsearch/pluginplussign/analysis/PlusSignAnalyzer.java
+++ b/src/main/java/org/elasticsearch/pluginplussign/analysis/PlusSignAnalyzer.java
@@ -1,4 +1,5 @@
-package io.citrine.pluginplussign.analysis;
+package org.elasticsearch.pluginplussign.analysis;
+
 import  org.apache.lucene.analysis.Analyzer;
 import  org.apache.lucene.analysis.TokenStream;
 import  org.apache.lucene.analysis.Tokenizer;
@@ -8,13 +9,13 @@ import  java.io.Reader;
 
 public class PlusSignAnalyzer extends Analyzer {
 
-    /* This is the only function that we need to override for our analyzer. It takes in a
-     * java.io.Reader object and saves the tokenizer and list of token filters that operate
-     * on it.
+    /* This is the only function that we need to override for our analyzer.
+     * It takes in a java.io.Reader object and saves the tokenizer and list
+     * of token filters that operate on it.
      */
     @Override
-    protected TokenStreamComponents createComponents(String field, Reader reader) {
-        Tokenizer tokenizer = new PlusSignTokenizer(reader);
+    protected TokenStreamComponents createComponents(String field) {
+        Tokenizer tokenizer = new PlusSignTokenizer();
         TokenStream filter = new EmptyStringTokenFilter(tokenizer);
         filter = new LowerCaseFilter(filter);
         return new TokenStreamComponents(tokenizer, filter);

--- a/src/main/java/org/elasticsearch/pluginplussign/analysis/PlusSignTokenizer.java
+++ b/src/main/java/org/elasticsearch/pluginplussign/analysis/PlusSignTokenizer.java
@@ -1,4 +1,5 @@
-package io.citrine.pluginplussign.analysis;
+package org.elasticsearch.pluginplussign.analysis;
+
 import  org.apache.lucene.analysis.Tokenizer;
 import  org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import  java.io.IOException;
@@ -59,20 +60,8 @@ public class PlusSignTokenizer extends Tokenizer {
      * IOException is found - you can choose how you want to deal with the IOException, but
      * for our purposes, we do not need to try to recover from it.
      */
-    public PlusSignTokenizer(Reader reader) {
-        super(reader);
-        int numChars;
-        char[] buffer = new char[1024];
-        StringBuilder stringBuilder = new StringBuilder();
-        try {
-            while ((numChars = reader.read(buffer, 0, buffer.length)) != -1) {
-                stringBuilder.append(buffer, 0, numChars);
-            }
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        this.stringToTokenize = stringBuilder.toString();
+    public PlusSignTokenizer() {
+        super();
     }
 
     /* Reset the stored position for this object when reset() is called.
@@ -81,6 +70,20 @@ public class PlusSignTokenizer extends Tokenizer {
     public void reset() throws IOException {
         super.reset();
         this.position = 0;
+
+        int numChars;
+        char[] buffer = new char[1024];
+        StringBuilder stringBuilder = new StringBuilder();
+
+        try {
+            while ((numChars = this.input.read(buffer, 0, buffer.length)) != -1) {
+                stringBuilder.append(buffer, 0, numChars);
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        this.stringToTokenize = stringBuilder.toString();
     }
 
     /* This object stores the string that we are turning into tokens. We will process its content

--- a/src/main/java/org/elasticsearch/pluginplussign/plugin/PlusSignAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/pluginplussign/plugin/PlusSignAnalyzerProvider.java
@@ -1,25 +1,27 @@
-package io.citrine.pluginplussign.plugin;
-import  io.citrine.pluginplussign.analysis.PlusSignAnalyzer;
+package org.elasticsearch.pluginplussign.plugin;
+
 import  org.elasticsearch.common.inject.Inject;
 import  org.elasticsearch.common.inject.assistedinject.Assisted;
 import  org.elasticsearch.common.settings.Settings;
 import  org.elasticsearch.env.Environment;
 import  org.elasticsearch.index.Index;
 import  org.elasticsearch.index.analysis.AbstractIndexAnalyzerProvider;
-import  org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.settings.IndexSettingsService;
+
+import org.elasticsearch.pluginplussign.analysis.PlusSignAnalyzer;
+
 import  java.io.IOException;
 
 public class PlusSignAnalyzerProvider extends AbstractIndexAnalyzerProvider<PlusSignAnalyzer> {
 
     /* Constructor. Nothing special here. */
     @Inject
-    public PlusSignAnalyzerProvider(Index index, @IndexSettings Settings indexSettings,
-    Environment env, @Assisted String name, @Assisted Settings settings) throws IOException {
-        super(index, indexSettings, name, settings);
+    public PlusSignAnalyzerProvider(Index index, IndexSettingsService indexSettingsService,
+                                    Environment env, @Assisted String name, @Assisted Settings settings) throws IOException {
+        super(index, indexSettingsService.getSettings(), name, settings);
     }
 
     /* This function needs to be overridden to return an instance of PlusSignAnalyzer. */
-    @Override
     public PlusSignAnalyzer get() {
         return this.analyzer;
     }

--- a/src/main/java/org/elasticsearch/pluginplussign/plugin/PlusSignBinderProcessor.java
+++ b/src/main/java/org/elasticsearch/pluginplussign/plugin/PlusSignBinderProcessor.java
@@ -1,4 +1,5 @@
-package io.citrine.pluginplussign.plugin;
+package org.elasticsearch.pluginplussign.plugin;
+
 import  org.elasticsearch.index.analysis.AnalysisModule;
 
 public class PlusSignBinderProcessor extends AnalysisModule.AnalysisBinderProcessor {
@@ -9,6 +10,6 @@ public class PlusSignBinderProcessor extends AnalysisModule.AnalysisBinderProces
     @Override
     public void processAnalyzers(AnalyzersBindings analyzersBindings) {
         analyzersBindings.processAnalyzer(PlusSignAnalyzerProvider.NAME,
-            PlusSignAnalyzerProvider.class);
+                PlusSignAnalyzerProvider.class);
     }
 }

--- a/src/main/java/org/elasticsearch/pluginplussign/plugin/PlusSignPlugin.java
+++ b/src/main/java/org/elasticsearch/pluginplussign/plugin/PlusSignPlugin.java
@@ -1,13 +1,14 @@
-package io.citrine.pluginplussign.plugin;
-import  org.elasticsearch.index.analysis.AnalysisModule;
-import  org.elasticsearch.plugins.AbstractPlugin;
+package org.elasticsearch.pluginplussign.plugin;
 
-public class PlusSignPlugin extends AbstractPlugin {
+import  org.elasticsearch.index.analysis.AnalysisModule;
+import  org.elasticsearch.plugins.Plugin;
+
+public class PlusSignPlugin extends Plugin {
 
     /* Set the name that will be assigned to this plugin. */
     @Override
     public String name() {
-        return "plugin-plussign";
+        return "Plus Sign Analyzer Test";
     }
 
     /* Return a description of this plugin. */

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -1,0 +1,12 @@
+# All plugins, be they site or Java plugins, must contain a file called plugin-descriptor.properties in the root directory.
+# Elasticsearch plugin descriptor file
+description=Plus Sign Analyzer Test
+version=1.0
+# 'name': the plugin name
+name=Plus Sign Analyzer Test
+jvm=true
+# 'classname': the name of the class to load, fully-qualified.
+#classname=com.netiq.scm.SCMPlugin
+classname=org.elasticsearch.pluginplussign.plugin.PlusSignPlugin
+java.version=1.8
+elasticsearch.version=2.2.0


### PR DESCRIPTION
I modify code for support ES 2.2.0 (I guess 2.x can be use too) .
But You need to make to .jar first [REF to this](https://www.elastic.co/guide/en/elasticsearch/plugins/2.2/plugin-authors.html#_mandatory_elements_for_java_plugins)

and put plugin-descriptor.properties into to root of plugin directory

![snip25600425_29](https://cloud.githubusercontent.com/assets/1525475/25383340/e348cdfe-29e5-11e7-82ef-aba2a0eaf3e0.png)

and finally it works :)
![snip25600425_27](https://cloud.githubusercontent.com/assets/1525475/25383175/16a0b000-29e5-11e7-9f0e-f1d619d3bb8e.png)
